### PR TITLE
fix IE<11 opacity bug

### DIFF
--- a/angular-dropdowns.css
+++ b/angular-dropdowns.css
@@ -55,8 +55,7 @@
   list-style: none;
 
   /* Hiding */
-  opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
 }
 
 .wrap-dd-select .dropdown li.divider {
@@ -119,8 +118,7 @@
 }
 
 .wrap-dd-select.active .dropdown {
-  opacity: 1;
-  pointer-events: auto;
+  visibility: visible;
 }
 
 /****** dropdown-menu *******/
@@ -151,8 +149,7 @@
   list-style: none;
 
   /* Hiding */
-  opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
 }
 
 .wrap-dd-menu .dropdown li.divider {
@@ -214,6 +211,5 @@
 }
 
 .wrap-dd-menu .dropdown.active {
-  opacity: 1;
-  pointer-events: auto;
+  visibility: visible;
 }


### PR DESCRIPTION
In IE<11 the dropdown menu is not visible, but it is still active and catches hidden menu items clicks.
In other words all content after dropdown is not available for click event.
See demo in IE10 http://jsfiddle.net/40L7tght/
