### PR TITLE
dropdownItemLabel promoted into scope variable

### DIFF
--- a/angular-dropdowns.js
+++ b/angular-dropdowns.js
@@ -68,11 +68,12 @@ dd.directive('dropdownSelect', ['DropdownService',
       scope: {
         dropdownSelect: '=',
         dropdownModel: '=',
+        dropdownItemLabel: '@',
         dropdownOnchange: '&'
       },
 
       controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
-        $scope.labelField = $attrs.dropdownItemLabel || 'text';
+        $scope.labelField = $scope.dropdownItemLabel || 'text';
 
         DropdownService.register($element);
 
@@ -131,11 +132,12 @@ dd.directive('dropdownMenu', ['$parse', '$compile', 'DropdownService', '$templat
       scope: {
         dropdownMenu: '=',
         dropdownModel: '=',
+        dropdownItemLabel: '@',
         dropdownOnchange: '&'
       },
 
       controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
-        $scope.labelField = $attrs.dropdownItemLabel || 'text';
+        $scope.labelField = $scope.dropdownItemLabel || 'text';
 
         var $template = angular.element($templateCache.get('ngDropdowns/templates/dropdownMenu.html'));
         // Attach this controller to the element's data


### PR DESCRIPTION
For dropdownSelect and dropdownMenu the dropdownItemLabel is not taken from the isolate scope variable rether than attrs to make the $interpolation of the value possible.