### PR TITLE
Load Angular over HTTPS on demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="example/normalize.css">
     <link rel="stylesheet" href="dist/angular-dropdowns.min.css">
     <link rel="stylesheet" href="example/page.css">
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.23/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.23/angular.min.js"></script>
     <script type="text/javascript" src="dist/angular-dropdowns.js"></script>
     <script type="text/javascript" src="example/app.js"></script>
   </head>


### PR DESCRIPTION
The example page is currently broken, as it's trying to load Angular over HTTP and Pages now uses HTTPS by default. This fixes the link.